### PR TITLE
Reworks, cleaning of code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.exe
 lope/files/
 *.txt
+*.lp

--- a/lope/files/operate.lp
+++ b/lope/files/operate.lp
@@ -1,2 +1,22 @@
-numero x = 2;
-x += 3;
+#*
+    +=
+    -=
+    *=
+    /=
+    %=
+    ~=
+    DASKAPITAL
+    ==
+    <=
+    >=
+    !=
+    ++
+    --
+    _
+    &&
+    ||
+    numero cudi = 404;
+    num yeezy = 808;
+    ,
+    kid_cudi64
+*#

--- a/lope/src/fileHandler.c
+++ b/lope/src/fileHandler.c
@@ -103,6 +103,7 @@ int scanFile(lexer_t *lexer)
         "Single Comment",
         "Multiple Comment",
         "Constant",
+        "Comma Separator"
         };
 
     while ((token = lexer_get_next_token(lexer)) != (void *)0)

--- a/lope/src/include/lexer.h
+++ b/lope/src/include/lexer.h
@@ -42,7 +42,5 @@ token_t *lexer_advance_with_token(lexer_t *lexer, token_t *token);
 char *lexer_get_current_char_as_string(lexer_t *lexer);
 int compare_to_keyword(char *identifier, char *keyword);
 token_t *lexer_collect_keyword(lexer_t *lexer);
-token_t *lexer_collect_comment_single(lexer_t *lexer);
-token_t *lexer_collect_comment_multi(lexer_t *lexer);
 
 #endif

--- a/lope/src/include/token.h
+++ b/lope/src/include/token.h
@@ -22,7 +22,7 @@ typedef struct TOKEN_STRUCT
         TOKEN_SUB,        // -
         TOKEN_DIV,        // /
         TOKEN_INTDIV,     // ~
-        TOKEN_MULT,       // \*
+        TOKEN_MULT,       // *
         TOKEN_MOD,        // %
         TOKEN_EXP,        // ^
         TOKEN_LESS,       // <
@@ -88,6 +88,7 @@ typedef struct TOKEN_STRUCT
         TOKEN_COMMENT_VALUE_MULTI,
         // for constant
         TOKEN_CAPITAL,
+        TOKEN_COMMA,
 
     } type;
 


### PR DESCRIPTION
- Added Comma Separator
- Reworked identifier/keyword tokenizing
	- Idea: Specifics -> general tokens
	- Trimmed down lines of code
- Fixed skip_whitespace() function
	- Included space, newline, and tab to be skipped
	- Trimmed down some functions
	- Fixed newline being tokenized as Invalid
- Added Logical Operators
- Fixed Comments
	- Were not working at first
	- Added feature to tokenize end of multi-line comment `*#`
- Added restriction to keywords/identifiers
	- No symbols aside from `_`
	- No numbers (will tokenize it as UNKNOWN)
